### PR TITLE
fix codeforces contest name extraction

### DIFF
--- a/src/commands/new.rs
+++ b/src/commands/new.rs
@@ -150,7 +150,7 @@ pub fn run(opt: OptCompeteNew, ctx: crate::Context<'_>) -> anyhow::Result<()> {
                 .get(0)
                 .and_then(|p| p.contest_url.as_ref())
                 .and_then(|url| url.path_segments())
-                .and_then(|segments| { segments }.next().map(ToOwned::to_owned))
+                .and_then(|segments| segments.skip(1).next().map(ToOwned::to_owned))
                 .with_context(|| "empty result")?;
             let group = Group::Codeforces(contest);
 

--- a/src/commands/new.rs
+++ b/src/commands/new.rs
@@ -150,7 +150,7 @@ pub fn run(opt: OptCompeteNew, ctx: crate::Context<'_>) -> anyhow::Result<()> {
                 .get(0)
                 .and_then(|p| p.contest_url.as_ref())
                 .and_then(|url| url.path_segments())
-                .and_then(|segments| segments.skip(1).next().map(ToOwned::to_owned))
+                .and_then(|segments| { segments }.nth(1).map(ToOwned::to_owned))
                 .with_context(|| "empty result")?;
             let group = Group::Codeforces(contest);
 


### PR DESCRIPTION
codeforces contest url is `https://codeforces.com/contest/{contest_id}`,
so should skip the first segment of the paths