### PR TITLE
Fix problem index

### DIFF
--- a/src/commands/add.rs
+++ b/src/commands/add.rs
@@ -156,11 +156,11 @@ pub(crate) fn run(opt: OptCompeteAdd, ctx: crate::Context<'_>) -> anyhow::Result
         Err(_) => if is_contest {
             oj_api::get_contest(&url, &metadata.workspace_root, shell)?
         } else {
-            vec![url]
+            vec![(url, None)]
         }
         .iter()
-        .map(|url| {
-            let problem = oj_api::get_problem(url, full, &metadata.workspace_root, shell)?;
+        .map(|(problem_url, _alphabet)| {
+            let problem = oj_api::get_problem(problem_url, full, &metadata.workspace_root, shell)?;
             Ok(crate::web::retrieve_testcases::Problem::from_oj_api(
                 problem, full,
             ))

--- a/src/commands/add.rs
+++ b/src/commands/add.rs
@@ -158,12 +158,14 @@ pub(crate) fn run(opt: OptCompeteAdd, ctx: crate::Context<'_>) -> anyhow::Result
         } else {
             vec![(url, None)]
         }
-        .iter()
-        .map(|(problem_url, _alphabet)| {
-            let problem = oj_api::get_problem(problem_url, full, &metadata.workspace_root, shell)?;
-            Ok(crate::web::retrieve_testcases::Problem::from_oj_api(
-                problem, full,
-            ))
+        .into_iter()
+        .map(|(problem_url, alphabet)| {
+            let problem = oj_api::get_problem(&problem_url, full, &metadata.workspace_root, shell)?;
+            let mut problem = crate::web::retrieve_testcases::Problem::from_oj_api(problem, full);
+            if let Some(problem_index) = alphabet {
+                problem.index = Some(problem_index);
+            }
+            Ok(problem)
         })
         .collect::<anyhow::Result<_>>()?,
     };

--- a/src/commands/new.rs
+++ b/src/commands/new.rs
@@ -271,7 +271,7 @@ pub fn run(opt: OptCompeteNew, ctx: crate::Context<'_>) -> anyhow::Result<()> {
 
             let outcome = oj_api::get_contest(contest_url, &cargo_compete_dir, shell)?
                 .into_iter()
-                .map(|problem_url| {
+                .map(|(problem_url, _alphabet)| {
                     let problem =
                         oj_api::get_problem(&problem_url, full, &cargo_compete_dir, shell)?;
                     let problem =

--- a/src/commands/new.rs
+++ b/src/commands/new.rs
@@ -271,13 +271,16 @@ pub fn run(opt: OptCompeteNew, ctx: crate::Context<'_>) -> anyhow::Result<()> {
 
             let outcome = oj_api::get_contest(contest_url, &cargo_compete_dir, shell)?
                 .into_iter()
-                .map(|(problem_url, _alphabet)| {
+                .map(|(problem_url, alphabet)| {
                     let problem =
                         oj_api::get_problem(&problem_url, full, &cargo_compete_dir, shell)?;
-                    let problem =
+                    let mut problem =
                         crate::web::retrieve_testcases::Problem::from_oj_api_with_alphabet(
                             problem, full,
                         )?;
+                    if let Some(index) = alphabet {
+                        problem.index = index;
+                    }
                     Ok((problem_url, problem))
                 })
                 .collect::<anyhow::Result<BTreeMap<_, _>>>()?;

--- a/src/oj_api.rs
+++ b/src/oj_api.rs
@@ -26,11 +26,11 @@ pub(crate) fn get_contest(
     url: &Url,
     cwd: &Utf8Path,
     shell: &mut Shell,
-) -> anyhow::Result<Vec<Url>> {
+) -> anyhow::Result<Vec<(Url, Option<String>)>> {
     let Contest { problems } = call(&["get-contest", url.as_ref()], cwd, shell)?;
     return Ok(problems
         .into_iter()
-        .map(|ContestProblem { url }| url)
+        .map(|ContestProblem { url, context }| (url, context.alphabet))
         .collect());
 
     #[derive(Deserialize)]
@@ -41,6 +41,12 @@ pub(crate) fn get_contest(
     #[derive(Deserialize)]
     struct ContestProblem {
         url: Url,
+        context: ContestProblemContext,
+    }
+
+    #[derive(Deserialize)]
+    struct ContestProblemContext {
+        alphabet: Option<String>,
     }
 }
 


### PR DESCRIPTION
AtCoder Problems の Virtual Contest でコンテスト内に同じ problem_index を複数持つものを oj-api 経由で `cargo compete new` すると、
同一の bin ターゲットに対して複数の問題を割り当てようとしてしまい、エラーになります。

そこで `oj_api::get_contest` で `alphabet` が取得できる場合に、そちらを使用するように修正しています。

## 再現手順

```console
$ cargo compete --version
cargo-compete 0.9.0

$ mkdir problem_index_bug

$ cd problem_index_bug/

$ cargo compete init atcoder
Do you use crates on AtCoder?
1 No
2 Yes
3 Yes, but I submit base64-encoded programs
1..3: 1
       Wrote /Users/bouzuya/problem_index_bug/./compete.toml
       Wrote /Users/bouzuya/problem_index_bug/./rust-toolchain
       Wrote /Users/bouzuya/problem_index_bug/./.cargo/config.toml

$ rm compete.toml

$ cat >compete.toml <<EOT
test-suite = "{{ manifest_dir }}/testcases/{{ bin_alias }}.yml"

[template]
src = '''
fn main() {
    todo!();
}
'''

[template.new]
dependencies = '''
#proconio = { version = "=0.3.6", features = ["derive"] }
'''
dev-dependencies = '''
#atcoder-202004-lock = { git = "https://github.com/qryxip/atcoder-202004-lock" }
'''

[template.new.copy-files]

[new]
kind = "oj-api"
url = "https://kenkoooo.com/atcoder/#/contest/show/{{ id }}"
path = "./{{ contest }}"

[test]
EOT

$ cargo compete new 'f428868b-527f-4ee2-bec7-810686bcc24d'
     Running `/usr/local/bin/oj-api get-contest 'https://kenkoooo.com/atcoder/#/contest/show/f428868b-527f-4ee2-bec7-810686bcc24d'` in /Users/bouzuya/problem_index_bug/
INFO:onlinejudge_api.main:online-judge-api-client 10.10.0
INFO:onlinejudge_api.main:sleep 1.000000 sec
INFO:onlinejudge.utils:load cookie from: /Users/bouzuya/Library/Application Support/online-judge-tools/cookie.jar
INFO:onlinejudge._implementation.utils:network: GET: https://kenkoooo.com/atcoder/resources/merged-problems.json
INFO:onlinejudge._implementation.utils:network: 200 OK
INFO:onlinejudge._implementation.utils:network: GET: https://kenkoooo.com/atcoder/internal-api/contest/get/f428868b-527f-4ee2-bec7-810686bcc24d
INFO:onlinejudge._implementation.utils:network: 200 OK
INFO:onlinejudge.utils:save cookie to: /Users/bouzuya/Library/Application Support/online-judge-tools/cookie.jar
     Running `/usr/local/bin/oj-api get-problem 'https://atcoder.jp/contests/abc100/tasks/abc100_b'` in /Users/bouzuya/problem_index_bug/
INFO:onlinejudge_api.main:online-judge-api-client 10.10.0
INFO:onlinejudge_api.main:sleep 1.000000 sec
INFO:onlinejudge.utils:load cookie from: /Users/bouzuya/Library/Application Support/online-judge-tools/cookie.jar
INFO:onlinejudge._implementation.utils:network: GET: https://atcoder.jp/contests/abc100/tasks/abc100_b
INFO:onlinejudge._implementation.utils:network: 200 OK
INFO:onlinejudge._implementation.utils:network: GET: https://atcoder.jp/contests/abc100/tasks/abc100_b
INFO:onlinejudge._implementation.utils:network: 200 OK
INFO:onlinejudge._implementation.utils:network: GET: https://atcoder.jp/contests/abc100?lang=en
INFO:onlinejudge._implementation.utils:network: 200 OK
INFO:onlinejudge.utils:save cookie to: /Users/bouzuya/Library/Application Support/online-judge-tools/cookie.jar
     Running `/usr/local/bin/oj-api get-problem 'https://atcoder.jp/contests/arc126/tasks/arc126_a'` in /Users/bouzuya/problem_index_bug/
INFO:onlinejudge_api.main:online-judge-api-client 10.10.0
INFO:onlinejudge_api.main:sleep 1.000000 sec
INFO:onlinejudge.utils:load cookie from: /Users/bouzuya/Library/Application Support/online-judge-tools/cookie.jar
INFO:onlinejudge._implementation.utils:network: GET: https://atcoder.jp/contests/arc126/tasks/arc126_a
INFO:onlinejudge._implementation.utils:network: 200 OK
INFO:onlinejudge._implementation.utils:network: GET: https://atcoder.jp/contests/arc126/tasks/arc126_a
INFO:onlinejudge._implementation.utils:network: 200 OK
INFO:onlinejudge._implementation.utils:network: GET: https://atcoder.jp/contests/arc126?lang=en
INFO:onlinejudge._implementation.utils:network: 200 OK
INFO:onlinejudge.utils:save cookie to: /Users/bouzuya/Library/Application Support/online-judge-tools/cookie.jar
     Running `/usr/local/bin/oj-api get-problem 'https://atcoder.jp/contests/agc029/tasks/agc029_a'` in /Users/bouzuya/problem_index_bug/
INFO:onlinejudge_api.main:online-judge-api-client 10.10.0
INFO:onlinejudge_api.main:sleep 1.000000 sec
INFO:onlinejudge.utils:load cookie from: /Users/bouzuya/Library/Application Support/online-judge-tools/cookie.jar
INFO:onlinejudge._implementation.utils:network: GET: https://atcoder.jp/contests/agc029/tasks/agc029_a
INFO:onlinejudge._implementation.utils:network: 200 OK
INFO:onlinejudge._implementation.utils:network: GET: https://atcoder.jp/contests/agc029/tasks/agc029_a
INFO:onlinejudge._implementation.utils:network: 200 OK
INFO:onlinejudge._implementation.utils:network: GET: https://atcoder.jp/contests/agc029?lang=en
INFO:onlinejudge._implementation.utils:network: 200 OK
INFO:onlinejudge.utils:save cookie to: /Users/bouzuya/Library/Application Support/online-judge-tools/cookie.jar
     Running `/usr/local/bin/oj-api get-problem 'https://atcoder.jp/contests/abc171/tasks/abc171_e'` in /Users/bouzuya/problem_index_bug/
INFO:onlinejudge_api.main:online-judge-api-client 10.10.0
INFO:onlinejudge_api.main:sleep 1.000000 sec
INFO:onlinejudge.utils:load cookie from: /Users/bouzuya/Library/Application Support/online-judge-tools/cookie.jar
INFO:onlinejudge._implementation.utils:network: GET: https://atcoder.jp/contests/abc171/tasks/abc171_e
INFO:onlinejudge._implementation.utils:network: 200 OK
INFO:onlinejudge._implementation.utils:network: GET: https://atcoder.jp/contests/abc171/tasks/abc171_e
INFO:onlinejudge._implementation.utils:network: 200 OK
INFO:onlinejudge._implementation.utils:network: GET: https://atcoder.jp/contests/abc171?lang=en
INFO:onlinejudge._implementation.utils:network: 200 OK
INFO:onlinejudge.utils:save cookie to: /Users/bouzuya/Library/Application Support/online-judge-tools/cookie.jar
     Running `/usr/local/bin/oj-api get-problem 'https://atcoder.jp/contests/agc036/tasks/agc036_a'` in /Users/bouzuya/problem_index_bug/
INFO:onlinejudge_api.main:online-judge-api-client 10.10.0
INFO:onlinejudge_api.main:sleep 1.000000 sec
INFO:onlinejudge.utils:load cookie from: /Users/bouzuya/Library/Application Support/online-judge-tools/cookie.jar
INFO:onlinejudge._implementation.utils:network: GET: https://atcoder.jp/contests/agc036/tasks/agc036_a
INFO:onlinejudge._implementation.utils:network: 200 OK
INFO:onlinejudge._implementation.utils:network: GET: https://atcoder.jp/contests/agc036/tasks/agc036_a
INFO:onlinejudge._implementation.utils:network: 200 OK
INFO:onlinejudge._implementation.utils:network: GET: https://atcoder.jp/contests/agc036?lang=en
INFO:onlinejudge._implementation.utils:network: 200 OK
INFO:onlinejudge.utils:save cookie to: /Users/bouzuya/Library/Application Support/online-judge-tools/cookie.jar
     Running `/usr/local/bin/oj-api get-problem 'https://atcoder.jp/contests/abc129/tasks/abc129_d'` in /Users/bouzuya/problem_index_bug/
INFO:onlinejudge_api.main:online-judge-api-client 10.10.0
INFO:onlinejudge_api.main:sleep 1.000000 sec
INFO:onlinejudge.utils:load cookie from: /Users/bouzuya/Library/Application Support/online-judge-tools/cookie.jar
INFO:onlinejudge._implementation.utils:network: GET: https://atcoder.jp/contests/abc129/tasks/abc129_d
INFO:onlinejudge._implementation.utils:network: 200 OK
INFO:onlinejudge._implementation.utils:network: GET: https://atcoder.jp/contests/abc129/tasks/abc129_d
INFO:onlinejudge._implementation.utils:network: 200 OK
INFO:onlinejudge._implementation.utils:network: GET: https://atcoder.jp/contests/abc129?lang=en
INFO:onlinejudge._implementation.utils:network: 200 OK
INFO:onlinejudge.utils:save cookie to: /Users/bouzuya/Library/Application Support/online-judge-tools/cookie.jar
     Running `/usr/local/bin/oj-api get-problem 'https://atcoder.jp/contests/abc218/tasks/abc218_e'` in /Users/bouzuya/problem_index_bug/
INFO:onlinejudge_api.main:online-judge-api-client 10.10.0
INFO:onlinejudge_api.main:sleep 1.000000 sec
INFO:onlinejudge.utils:load cookie from: /Users/bouzuya/Library/Application Support/online-judge-tools/cookie.jar
INFO:onlinejudge._implementation.utils:network: GET: https://atcoder.jp/contests/abc218/tasks/abc218_e
INFO:onlinejudge._implementation.utils:network: 200 OK
INFO:onlinejudge._implementation.utils:network: GET: https://atcoder.jp/contests/abc218/tasks/abc218_e
INFO:onlinejudge._implementation.utils:network: 200 OK
INFO:onlinejudge._implementation.utils:network: GET: https://atcoder.jp/contests/abc218?lang=en
INFO:onlinejudge._implementation.utils:network: 200 OK
INFO:onlinejudge.utils:save cookie to: /Users/bouzuya/Library/Application Support/online-judge-tools/cookie.jar
     Running `/usr/local/bin/oj-api get-problem 'https://atcoder.jp/contests/abc004/tasks/abc004_4'` in /Users/bouzuya/problem_index_bug/
INFO:onlinejudge_api.main:online-judge-api-client 10.10.0
INFO:onlinejudge_api.main:sleep 1.000000 sec
INFO:onlinejudge.utils:load cookie from: /Users/bouzuya/Library/Application Support/online-judge-tools/cookie.jar
INFO:onlinejudge._implementation.utils:network: GET: https://atcoder.jp/contests/abc004/tasks/abc004_4
INFO:onlinejudge._implementation.utils:network: 200 OK
INFO:onlinejudge._implementation.utils:network: GET: https://atcoder.jp/contests/abc004/tasks/abc004_4
INFO:onlinejudge._implementation.utils:network: 200 OK
INFO:onlinejudge._implementation.utils:network: GET: https://atcoder.jp/contests/abc004?lang=en
INFO:onlinejudge._implementation.utils:network: 200 OK
INFO:onlinejudge.utils:save cookie to: /Users/bouzuya/Library/Application Support/online-judge-tools/cookie.jar
     Running `/usr/local/bin/oj-api get-problem 'https://atcoder.jp/contests/abc017/tasks/abc017_4'` in /Users/bouzuya/problem_index_bug/
INFO:onlinejudge_api.main:online-judge-api-client 10.10.0
INFO:onlinejudge_api.main:sleep 1.000000 sec
INFO:onlinejudge.utils:load cookie from: /Users/bouzuya/Library/Application Support/online-judge-tools/cookie.jar
INFO:onlinejudge._implementation.utils:network: GET: https://atcoder.jp/contests/abc017/tasks/abc017_4
INFO:onlinejudge._implementation.utils:network: 200 OK
INFO:onlinejudge._implementation.utils:network: GET: https://atcoder.jp/contests/abc017/tasks/abc017_4
INFO:onlinejudge._implementation.utils:network: 200 OK
INFO:onlinejudge._implementation.utils:network: GET: https://atcoder.jp/contests/abc017?lang=en
INFO:onlinejudge._implementation.utils:network: 200 OK
INFO:onlinejudge.utils:save cookie to: /Users/bouzuya/Library/Application Support/online-judge-tools/cookie.jar
     Running `/usr/local/bin/oj-api get-problem 'https://atcoder.jp/contests/code-festival-2014-morning-easy/tasks/code_festival_morning_easy_d'` in /Users/bouzuya/problem_index_bug/
INFO:onlinejudge_api.main:online-judge-api-client 10.10.0
INFO:onlinejudge_api.main:sleep 1.000000 sec
INFO:onlinejudge.utils:load cookie from: /Users/bouzuya/Library/Application Support/online-judge-tools/cookie.jar
INFO:onlinejudge._implementation.utils:network: GET: https://atcoder.jp/contests/code-festival-2014-morning-easy/tasks/code_festival_morning_easy_d
INFO:onlinejudge._implementation.utils:network: 200 OK
INFO:onlinejudge._implementation.utils:network: GET: https://atcoder.jp/contests/code-festival-2014-morning-easy/tasks/code_festival_morning_easy_d
INFO:onlinejudge._implementation.utils:network: 200 OK
INFO:onlinejudge._implementation.utils:network: GET: https://atcoder.jp/contests/code-festival-2014-morning-easy?lang=en
INFO:onlinejudge._implementation.utils:network: 200 OK
INFO:onlinejudge.utils:save cookie to: /Users/bouzuya/Library/Application Support/online-judge-tools/cookie.jar
     Running `/usr/local/bin/oj-api get-problem 'https://atcoder.jp/contests/aising2019/tasks/aising2019_d'` in /Users/bouzuya/problem_index_bug/
INFO:onlinejudge_api.main:online-judge-api-client 10.10.0
INFO:onlinejudge_api.main:sleep 1.000000 sec
INFO:onlinejudge.utils:load cookie from: /Users/bouzuya/Library/Application Support/online-judge-tools/cookie.jar
INFO:onlinejudge._implementation.utils:network: GET: https://atcoder.jp/contests/aising2019/tasks/aising2019_d
INFO:onlinejudge._implementation.utils:network: 200 OK
INFO:onlinejudge._implementation.utils:network: GET: https://atcoder.jp/contests/aising2019/tasks/aising2019_d
INFO:onlinejudge._implementation.utils:network: 200 OK
INFO:onlinejudge._implementation.utils:network: GET: https://atcoder.jp/contests/aising2019?lang=en
INFO:onlinejudge._implementation.utils:network: 200 OK
INFO:onlinejudge.utils:save cookie to: /Users/bouzuya/Library/Application Support/online-judge-tools/cookie.jar
     Running `/usr/local/bin/oj-api get-problem 'https://atcoder.jp/contests/agc013/tasks/agc013_b'` in /Users/bouzuya/problem_index_bug/
INFO:onlinejudge_api.main:online-judge-api-client 10.10.0
INFO:onlinejudge_api.main:sleep 1.000000 sec
INFO:onlinejudge.utils:load cookie from: /Users/bouzuya/Library/Application Support/online-judge-tools/cookie.jar
INFO:onlinejudge._implementation.utils:network: GET: https://atcoder.jp/contests/agc013/tasks/agc013_b
INFO:onlinejudge._implementation.utils:network: 200 OK
INFO:onlinejudge._implementation.utils:network: GET: https://atcoder.jp/contests/agc013/tasks/agc013_b
INFO:onlinejudge._implementation.utils:network: 200 OK
INFO:onlinejudge._implementation.utils:network: GET: https://atcoder.jp/contests/agc013?lang=en
INFO:onlinejudge._implementation.utils:network: 200 OK
INFO:onlinejudge.utils:save cookie to: /Users/bouzuya/Library/Application Support/online-judge-tools/cookie.jar
     Running `/usr/local/bin/oj-api get-problem 'https://atcoder.jp/contests/abc206/tasks/abc206_e'` in /Users/bouzuya/problem_index_bug/
INFO:onlinejudge_api.main:online-judge-api-client 10.10.0
INFO:onlinejudge_api.main:sleep 1.000000 sec
INFO:onlinejudge.utils:load cookie from: /Users/bouzuya/Library/Application Support/online-judge-tools/cookie.jar
INFO:onlinejudge._implementation.utils:network: GET: https://atcoder.jp/contests/abc206/tasks/abc206_e
INFO:onlinejudge._implementation.utils:network: 200 OK
INFO:onlinejudge._implementation.utils:network: GET: https://atcoder.jp/contests/abc206/tasks/abc206_e
INFO:onlinejudge._implementation.utils:network: 200 OK
INFO:onlinejudge._implementation.utils:network: GET: https://atcoder.jp/contests/abc206?lang=en
INFO:onlinejudge._implementation.utils:network: 200 OK
INFO:onlinejudge.utils:save cookie to: /Users/bouzuya/Library/Application Support/online-judge-tools/cookie.jar
     Created `f428868b-527f-4ee2-bec7-810686bcc24d` package at /Users/bouzuya/problem_index_bug/./f428868b-527f-4ee2-bec7-810686bcc24d
       Saved 3 test cases to /Users/bouzuya/problem_index_bug/./f428868b-527f-4ee2-bec7-810686bcc24d/testcases/{d.yml, d/}
       Saved 2 test cases to /Users/bouzuya/problem_index_bug/./f428868b-527f-4ee2-bec7-810686bcc24d/testcases/{d.yml, d/}
       Saved 3 test cases to /Users/bouzuya/problem_index_bug/./f428868b-527f-4ee2-bec7-810686bcc24d/testcases/{b.yml, b/}
       Saved 2 test cases to /Users/bouzuya/problem_index_bug/./f428868b-527f-4ee2-bec7-810686bcc24d/testcases/{d.yml, d/}
       Saved 1 test case to /Users/bouzuya/problem_index_bug/./f428868b-527f-4ee2-bec7-810686bcc24d/testcases/{e.yml, e/}
       Saved 3 test cases to /Users/bouzuya/problem_index_bug/./f428868b-527f-4ee2-bec7-810686bcc24d/testcases/{e.yml, e/}
       Saved 3 test cases to /Users/bouzuya/problem_index_bug/./f428868b-527f-4ee2-bec7-810686bcc24d/testcases/{e.yml, e/}
       Saved 3 test cases to /Users/bouzuya/problem_index_bug/./f428868b-527f-4ee2-bec7-810686bcc24d/testcases/{b.yml, b/}
       Saved 2 test cases to /Users/bouzuya/problem_index_bug/./f428868b-527f-4ee2-bec7-810686bcc24d/testcases/{a.yml, a/}
       Saved 3 test cases to /Users/bouzuya/problem_index_bug/./f428868b-527f-4ee2-bec7-810686bcc24d/testcases/{a.yml, a/}
       Saved 2 test cases to /Users/bouzuya/problem_index_bug/./f428868b-527f-4ee2-bec7-810686bcc24d/testcases/{d.yml, d/}
       Saved 1 test case to /Users/bouzuya/problem_index_bug/./f428868b-527f-4ee2-bec7-810686bcc24d/testcases/{a.yml, a/}
       Saved 3 test cases to /Users/bouzuya/problem_index_bug/./f428868b-527f-4ee2-bec7-810686bcc24d/testcases/{d.yml, d/}
thread 'main' panicked at 'itertools: .zip_eq() reached end of one iterator before the other', /Users/bouzuya/.cargo/registry/src/github.com-1ecc6299db9ec823/itertools-0.10.1/src/zip_eq_impl.rs:48:13
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
