### PR TITLE
Add a Bind feature

### DIFF
--- a/src/commands/new.rs
+++ b/src/commands/new.rs
@@ -404,29 +404,23 @@ fn create_new_package(
         );
     }
 
-    let mut package_metadata_cargo_compete_bin = problems
-        .keys()
-        .map(|problem_index| {
+    let package_metadata_cargo_compete_bin = problems
+        .iter()
+        .map(|(problem_index, problem_url)| {
             format!(
-                r#"{} = {{ alias = "", problem = "" }}
+                r#"{} = {{ alias = "{}", problem = "{}" }}
 "#,
                 escape_key(&format!(
                     "{}-{}",
                     group.package_name(),
-                    problem_index.to_kebab_case(),
-                )),
+                    problem_index.to_kebab_case()
+                ),),
+                problem_index.to_kebab_case(),
+                problem_url.as_str()
             )
         })
         .join("")
         .parse::<toml_edit::Document>()?;
-
-    for (problem_index, problem_url) in problems {
-        let bin_name = &format!("{}-{}", group.package_name(), problem_index.to_kebab_case());
-        let bin_alias = problem_index.to_kebab_case();
-        let problem_url = problem_url.as_str();
-        package_metadata_cargo_compete_bin[bin_name]["alias"] = toml_edit::value(bin_alias);
-        package_metadata_cargo_compete_bin[bin_name]["problem"] = toml_edit::value(problem_url);
-    }
 
     let bin = toml_edit::Item::ArrayOfTables({
         let mut arr = toml_edit::ArrayOfTables::new();

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -32,6 +32,12 @@ pub(crate) struct Args<'a> {
     pub(crate) display_limit: Size,
     pub(crate) cookies_path: &'a Path,
     pub(crate) shell: &'a mut Shell,
+    pub(crate) bind: Bind,
+}
+#[derive(Debug)]
+pub(crate) struct Bind {
+    pub(crate) name: String,
+    pub(crate) should_use: bool,
 }
 
 pub(crate) fn test(args: Args<'_>) -> anyhow::Result<()> {
@@ -48,6 +54,7 @@ pub(crate) fn test(args: Args<'_>) -> anyhow::Result<()> {
         display_limit,
         cookies_path,
         shell,
+        bind,
     } = args;
 
     let test_suite_path = test_suite_path(
@@ -146,7 +153,11 @@ pub(crate) fn test(args: Args<'_>) -> anyhow::Result<()> {
     } else {
         "--bin"
     })
-    .arg(&bin.name)
+    .arg(if bind.should_use {
+        &bind.name
+    } else {
+        &bin.name
+    })
     .args(if release { &["--release"] } else { &[] })
     .arg("--manifest-path")
     .arg(&member.manifest_path)
@@ -161,7 +172,11 @@ pub(crate) fn test(args: Args<'_>) -> anyhow::Result<()> {
         } else {
             ""
         })
-        .join(&bin.name)
+        .join(if bind.should_use {
+            &bind.name
+        } else {
+            &bin.name
+        })
         .with_extension(env::consts::EXE_EXTENSION);
 
     ensure!(


### PR DESCRIPTION
Thank you for watching PR while you are busy.
This PR includes a Bind feature for cargo-compete.

### Overview
The folder created by the `new` subcommand basically has a one-to-one association between the filename and bin, but I have added the feature that allows you to associate one bin with multiple files.

### Reason for addition
There are situations where you have multiple solutions to the same problem in the same project, or that you want to run tests on multiple files in different filenames. Adding a `bin` to Cargo.toml and creating the same test cases can be tedious, so it's useful to have this feature in those cases.

### Feature
If you want to run against a test case, for example, if you want to test alias `a` for files other than `a.rs`, separate them with `_`, such as `{alias}_dfs.rs`. (Make sure that alias comes at the beginning when parsing) In this case, `a_dfs.rs` will be tested for the test for `a`. (The same applies when `submit` subcommand)

### Affected Files
・The part where `bin_name` or `alias` is used in `src/commands/test.rs` and ` src/commands/submit.rs`
・The part where checking if a target exists and making sure which target is which in`src/project.rs` called from  `src/commands/test.rs` and `src/commands/submit.rs` 
・The part where to pass `bin` as an argument in `src/testing.rs`


If you find it useful, please consider merging!

Thanks
