### PR TITLE
Add a Bind feature

### DIFF
--- a/src/commands/new.rs
+++ b/src/commands/new.rs
@@ -404,29 +404,23 @@ fn create_new_package(
         );
     }
 
-    let mut package_metadata_cargo_compete_bin = problems
-        .keys()
-        .map(|problem_index| {
+    let package_metadata_cargo_compete_bin = problems
+        .iter()
+        .map(|(problem_index, problem_url)| {
             format!(
-                r#"{} = {{ alias = "", problem = "" }}
+                r#"{} = {{ alias = "{}", problem = "{}" }}
 "#,
                 escape_key(&format!(
                     "{}-{}",
                     group.package_name(),
-                    problem_index.to_kebab_case(),
-                )),
+                    problem_index.to_kebab_case()
+                ),),
+                problem_index.to_kebab_case(),
+                problem_url.as_str()
             )
         })
         .join("")
         .parse::<toml_edit::Document>()?;
-
-    for (problem_index, problem_url) in problems {
-        let bin_name = &format!("{}-{}", group.package_name(), problem_index.to_kebab_case());
-        let bin_alias = problem_index.to_kebab_case();
-        let problem_url = problem_url.as_str();
-        package_metadata_cargo_compete_bin[bin_name]["alias"] = toml_edit::value(bin_alias);
-        package_metadata_cargo_compete_bin[bin_name]["problem"] = toml_edit::value(problem_url);
-    }
 
     let bin = toml_edit::Item::ArrayOfTables({
         let mut arr = toml_edit::ArrayOfTables::new();

--- a/tests/snapshots/test__atcoder_practice_a_file_tree.snap
+++ b/tests/snapshots/test__atcoder_practice_a_file_tree.snap
@@ -10,7 +10,7 @@ expression: tree
   "compete.toml": "test-suite = \"{{ manifest_dir }}/testcases/{{ bin_alias | kebabcase }}.yml\"\n\n[template]\nsrc = '''\nfn main() {\n    todo!();\n}\n'''\n\n[template.new]\ndependencies = '''\nproconio = \"=0.3.6\"\n'''\n\n[new]\nplatform = \"atcoder\"\npath = \"./{{ package_name }}\"\n",
   "practice": {
     "Cargo.lock": "..",
-    "Cargo.toml": "[package]\nname = \"problems\"\nversion = \"0.1.0\"\nedition = \"2018\"\n\n[package.metadata.cargo-compete.bin]\npractice-a = { alias = \"a\", problem = \"https://atcoder.jp/contests/practice/tasks/practice_1\" }\n\n[[bin]]\nname = \"practice-a\"\npath = \"src/bin/a.rs\"\n\n[dependencies]\nproconio = \"=0.3.6\"\n",
+    "Cargo.toml": "[package]\nname = \"practice\"\nversion = \"0.1.0\"\nedition = \"2018\"\n\n[package.metadata.cargo-compete.bin]\npractice-a = { alias = \"a\", problem = \"https://atcoder.jp/contests/practice/tasks/practice_1\" }\n\n[[bin]]\nname = \"practice-a\"\npath = \"src/bin/a.rs\"\n\n[dependencies]\nproconio = \"=0.3.6\"\n",
     "src": {
       "bin": {
         "a.rs": "use proconio::input;\n\nfn main() {\n    input! {\n        a: u32,\n        b: u32,\n        c: u32,\n        s: String,\n    }\n\n    println!(\"{} {}\", a + b + c, s);\n}\n"

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -101,7 +101,7 @@ target-dir = "target"
                 cwd.join(contest).join("Cargo.toml"),
                 format!(
                     r#"[package]
-name = "problems"
+name = "{contest}"
 version = "0.1.0"
 edition = "2018"
 


### PR DESCRIPTION

To: @qryxip

Thank you for reviewing this PR while you are busy.

This PR includes a Bind feature for cargo-compete.
### Overview

The folder created by the `new` subcommand basically has a one-to-one association between the filename and bin, but this Bind feature allows you to associate one bin with multiple files.
### Reason for addition

There are situations where you have multiple solutions (thus, have multiple files) to the same problem in the same project, so that you want to run same tests on multiple files in different filenames. Because adding a bin for each difference filename to `Cargo.toml` and creating the same test cases can be tedious, it is useful to have this feature in those cases.
### Feature

If you want to run against a test case, for example, to test alias `a` for files other than `a.rs`, you can just separate alias name with `_`, i.g. `{alias}_dfs.rs`. (And make sure that an alias comes at the beginning) In this case, `a_dfs.rs` will be tested for the test for `a`. (The same feature applies to `submit` subcommand)
### Affected Files

・The part where bin_name or alias is used in `src/commands/test.rs` and `src/commands/submit.rs`
・The part where checking if a target exists and making sure which target is which in `src/project.rs` called from `src/commands/test.rs` and `src/commands/submit.rs`
・The part where to pass bin as an argument in `src/testing.rs`

If there is anything unclear, please let me explain, and correct me if anything I misunderstand any part in existing codes!
If everything seems fine and you find it useful, please consider for merging!

Thank you,

Ryota
