### PR TITLE
fix clippy errors

### DIFF
--- a/src/commands/add.rs
+++ b/src/commands/add.rs
@@ -85,7 +85,7 @@ pub(crate) fn run(opt: OptCompeteAdd, ctx: crate::Context<'_>) -> anyhow::Result
     ensure!(!url.is_empty(), "empty URL for {:?}", args);
     let url = url
         .parse::<Url>()
-        .with_context(|| format!("could not parse {:?} as a URL", url))?;
+        .with_context(|| format!("could not parse {url:?} as a URL"))?;
 
     let is_contest = if let Some(args) = &cargo_compete_config_add.is_contest {
         ensure!(!args.is_empty(), "`add.is-contest` is empty");
@@ -253,7 +253,7 @@ pub(crate) fn run(opt: OptCompeteAdd, ctx: crate::Context<'_>) -> anyhow::Result
 
         let default_src_path = Path::new("src")
             .join("bin")
-            .join(&bin_name)
+            .join(bin_name)
             .with_extension("rs");
 
         if Path::new(bin_src_path)

--- a/src/commands/add.rs
+++ b/src/commands/add.rs
@@ -67,7 +67,7 @@ pub(crate) fn run(opt: OptCompeteAdd, ctx: crate::Context<'_>) -> anyhow::Result
     let manifest_path = manifest_path
         .map(|p| Ok(cwd.join(p.strip_prefix(".").unwrap_or(&p))))
         .unwrap_or_else(|| crate::project::locate_project(&cwd))?;
-    let metadata = crate::project::cargo_metadata(&manifest_path, cwd)?;
+    let metadata = crate::project::cargo_metadata(manifest_path, cwd)?;
     let member = metadata.query_for_member(package.as_deref())?;
     let (cargo_compete_config, cargo_compete_config_path) =
         crate::config::load_for_package(member, shell)?;

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -87,8 +87,8 @@ pub(crate) fn run(opt: OptCompeteInit, ctx: crate::Context<'_>) -> anyhow::Resul
                 PlatformKind::Yukicoder => YUKICODER_RUST_EDITION,
             },
             (atcoder_crates == AtcoderCrates::UseNormally)
-                .then(|| include_str!("../../resources/atcoder-deps.toml")),
-            (atcoder_crates == AtcoderCrates::UseNormally).then(|| TEMPLATE_CARGO_LOCK),
+                .then_some(include_str!("../../resources/atcoder-deps.toml")),
+            (atcoder_crates == AtcoderCrates::UseNormally).then_some(TEMPLATE_CARGO_LOCK),
             platform,
             match platform {
                 PlatformKind::Atcoder => ATCODER_RUST_VERSION,

--- a/src/commands/migrate_cargo_atcoder.rs
+++ b/src/commands/migrate_cargo_atcoder.rs
@@ -166,7 +166,7 @@ pub(crate) fn run(
         let lock_path = &package.manifest_path.with_file_name("Cargo.lock");
         shell.status("Updating", lock_path)?;
         if let Err(err) = crate::project::cargo_metadata(&package.manifest_path, &cwd) {
-            shell.warn(format!("broke `{}`!!!!!: {}", lock_path, err))?;
+            shell.warn(format!("broke `{lock_path}`!!!!!: {err}"))?;
         }
     }
 

--- a/src/commands/new.rs
+++ b/src/commands/new.rs
@@ -360,7 +360,7 @@ impl Group {
 
     fn package_name(&self) -> String {
         let mut package_name = self.contest().unwrap_or("problems").to_owned();
-        if package_name.starts_with(|c:char| c.is_ascii_digit()) {
+        if package_name.starts_with(|c: char| c.is_ascii_digit()) {
             package_name = format!("contest{package_name}");
         }
         package_name
@@ -376,9 +376,7 @@ fn create_new_package(
 ) -> anyhow::Result<(Utf8PathBuf, Vec<Utf8PathBuf>)> {
     let template = cargo_compete_config.template(cargo_compete_config_path, shell)?;
     let template_new = template.new.as_ref().with_context(|| {
-        format!(
-            "`template.new` is required for the command: {cargo_compete_config_path}",
-        )
+        format!("`template.new` is required for the command: {cargo_compete_config_path}",)
     })?;
 
     let manifest_dir = cargo_compete_config

--- a/src/commands/new.rs
+++ b/src/commands/new.rs
@@ -360,8 +360,8 @@ impl Group {
 
     fn package_name(&self) -> String {
         let mut package_name = self.contest().unwrap_or("problems").to_owned();
-        if package_name.starts_with(|c| ('0'..='9').contains(&c)) {
-            package_name = format!("contest{}", package_name);
+        if package_name.starts_with(|c:char| c.is_ascii_digit()) {
+            package_name = format!("contest{package_name}");
         }
         package_name
     }
@@ -377,15 +377,14 @@ fn create_new_package(
     let template = cargo_compete_config.template(cargo_compete_config_path, shell)?;
     let template_new = template.new.as_ref().with_context(|| {
         format!(
-            "`template.new` is required for the command: {}",
-            cargo_compete_config_path,
+            "`template.new` is required for the command: {cargo_compete_config_path}",
         )
     })?;
 
     let manifest_dir = cargo_compete_config
         .new
         .path()
-        .with_context(|| format!("`new` is `none`: {}", cargo_compete_config_path))?
+        .with_context(|| format!("`new` is `none`: {cargo_compete_config_path}"))?
         .render(&object!({
             "contest": group.contest(),
             "package_name": group.package_name(),
@@ -462,7 +461,7 @@ edition = ""
         profile.set_implicit(true);
         let mut head = toml_edit::Document::new();
         head["profile"] = toml_edit::Item::Table(profile);
-        format!("{}\n{}", head, MANIFEST_TEMPLATE)
+        format!("{head}\n{MANIFEST_TEMPLATE}")
     }
     .parse::<toml_edit::Document>()?;
 
@@ -472,8 +471,7 @@ edition = ""
             edition.to_string()
         } else {
             shell.warn(format!(
-                "missing `template.new.edition` in `{}`. setting `\"2018\"`",
-                cargo_compete_config_path,
+                "missing `template.new.edition` in `{cargo_compete_config_path}`. setting `\"2018\"`",
             ))?;
             "2018".to_owned()
         }

--- a/src/commands/new.rs
+++ b/src/commands/new.rs
@@ -504,7 +504,7 @@ edition = ""
     let src_bin_dir = manifest_dir.join("src").join("bin");
 
     crate::fs::create_dir_all(&src_bin_dir)?;
-    crate::fs::write(&manifest_path, manifest.to_string())?;
+    crate::fs::write(manifest_path, manifest.to_string())?;
 
     let src_paths = problems
         .keys()

--- a/src/commands/open.rs
+++ b/src/commands/open.rs
@@ -65,7 +65,7 @@ pub(crate) fn run(opt: OptCompeteOpen, ctx: crate::Context<'_>) -> anyhow::Resul
     let manifest_path = manifest_path
         .map(|p| Ok(cwd.join(p.strip_prefix(".").unwrap_or(&p))))
         .unwrap_or_else(|| crate::project::locate_project(&cwd))?;
-    let metadata = crate::project::cargo_metadata(&manifest_path, cwd)?;
+    let metadata = crate::project::cargo_metadata(manifest_path, cwd)?;
     let member = metadata.query_for_member(package.as_deref())?;
     let package_metadata = member.read_package_metadata(shell)?;
     let (cargo_compete_config, _) = crate::config::load_for_package(member, shell)?;

--- a/src/commands/retrieve_submission_summaries.rs
+++ b/src/commands/retrieve_submission_summaries.rs
@@ -59,7 +59,7 @@ pub(crate) fn run(
     let manifest_path = manifest_path
         .map(|p| Ok(cwd.join(p.strip_prefix(".").unwrap_or(&p))))
         .unwrap_or_else(|| crate::project::locate_project(&cwd))?;
-    let metadata = crate::project::cargo_metadata(&manifest_path, cwd)?;
+    let metadata = crate::project::cargo_metadata(manifest_path, cwd)?;
     let member = metadata.query_for_member(package.as_deref())?;
     let package_metadata = member.read_package_metadata(shell)?;
     crate::config::load_for_package(member, shell)?;

--- a/src/commands/retrieve_testcases.rs
+++ b/src/commands/retrieve_testcases.rs
@@ -69,7 +69,7 @@ pub(crate) fn run(opt: OptCompeteRetrieveTestcases, ctx: crate::Context<'_>) -> 
     let manifest_path = manifest_path
         .map(|p| Ok(cwd.join(p.strip_prefix(".").unwrap_or(&p))))
         .unwrap_or_else(|| crate::project::locate_project(&cwd))?;
-    let metadata = crate::project::cargo_metadata(&manifest_path, cwd)?;
+    let metadata = crate::project::cargo_metadata(manifest_path, cwd)?;
     let member = metadata.query_for_member(package.as_deref())?;
     let package_metadata = member.read_package_metadata(shell)?;
     let (cargo_compete_config, _) = crate::config::load_for_package(member, shell)?;

--- a/src/commands/submit.rs
+++ b/src/commands/submit.rs
@@ -114,7 +114,7 @@ pub(crate) fn run(opt: OptCompeteSubmit, ctx: crate::Context<'_>) -> anyhow::Res
     let manifest_path = manifest_path
         .map(|p| Ok(cwd.join(p.strip_prefix(".").unwrap_or(&p))))
         .unwrap_or_else(|| crate::project::locate_project(&cwd))?;
-    let metadata = crate::project::cargo_metadata(&manifest_path, &cwd)?;
+    let metadata = crate::project::cargo_metadata(manifest_path, &cwd)?;
     let member = metadata.query_for_member(package.as_deref())?;
     let package_metadata = member.read_package_metadata(shell)?;
     let (cargo_compete_config, _) = crate::config::load_for_package(member, shell)?;
@@ -372,7 +372,7 @@ fn print_status(shell: &mut Shell, rows: &[Row]) -> io::Result<()> {
         .separator(LinePosition::Bottom, LineSeparator::new('─', '┴', '└', '┘'))
         .build();
     table.extend(rows.iter().cloned());
-    write!(shell.err(), "{}", table)?;
+    write!(shell.err(), "{table}")?;
     shell.err().flush()?;
     shell.status("Successfully", "submitted the code")
 }

--- a/src/commands/test.rs
+++ b/src/commands/test.rs
@@ -85,7 +85,7 @@ pub(crate) fn run(opt: OptCompeteTest, ctx: crate::Context<'_>) -> anyhow::Resul
     let manifest_path = manifest_path
         .map(|p| Ok(cwd.join(p.strip_prefix(".").unwrap_or(&p))))
         .unwrap_or_else(|| crate::project::locate_project(&cwd))?;
-    let metadata = crate::project::cargo_metadata(&manifest_path, &cwd)?;
+    let metadata = crate::project::cargo_metadata(manifest_path, &cwd)?;
     let member = metadata.query_for_member(package.as_deref())?;
     let package_metadata = member.read_package_metadata(shell)?;
     let (cargo_compete_config, _) = crate::config::load_for_package(member, shell)?;

--- a/src/config.rs
+++ b/src/config.rs
@@ -85,7 +85,7 @@ pub(crate) fn load(
     .with_context(|| format!("could not read a TOML file at `{}`", path.display()))?;
 
     for unused in &*unused {
-        shell.warn(format!("unused key in compete.toml: {}", unused))?;
+        shell.warn(format!("unused key in compete.toml: {unused}"))?;
     }
 
     Ok(config)
@@ -105,9 +105,8 @@ pub(crate) fn load_for_package(
             .find(|p| p.exists())
             .with_context(|| {
                 format!(
-                    "could not find `compete.toml` in `{}` or any parent directory. first, create \
+                    "could not find `compete.toml` in `{manifest_dir}` or any parent directory. first, create \
                      one  with `cargo compete init`",
-                    manifest_dir,
                 )
             })?
     };

--- a/src/config.rs
+++ b/src/config.rs
@@ -594,6 +594,7 @@ where
         .map_err(D::Error::custom)
 }
 
+#[allow(clippy::box_default)]
 fn liquid_template_with_custom_filter(text: &str) -> Result<liquid::Template, String> {
     use liquid::ParserBuilder;
     use liquid_core::{Filter, Runtime, Value, ValueView};

--- a/src/config.rs
+++ b/src/config.rs
@@ -643,8 +643,8 @@ mod tests {
             let generated = super::generate(
                 "2018",
                 template_new_dependencies_content
-                    .then(|| include_str!("../resources/atcoder-deps.toml")),
-                template_new_lockfile.then(|| "./cargo-lock-template.toml"),
+                    .then_some(include_str!("../resources/atcoder-deps.toml")),
+                template_new_lockfile.then_some("./cargo-lock-template.toml"),
                 PlatformKind::Atcoder,
                 "1.42.0",
                 submit_via_bianry,

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,14 +48,14 @@ fn exit_with_error(err: anyhow::Error, mut wtr: impl WriteColor) -> ! {
     let _ = wtr.set_color(&bold_red);
     let _ = write!(wtr, "error:");
     let _ = wtr.reset();
-    let _ = writeln!(wtr, " {}", err);
+    let _ = writeln!(wtr, " {err}");
 
     for cause in err.chain().skip(1) {
         let _ = writeln!(wtr);
         let _ = wtr.set_color(&bold_red);
         let _ = write!(wtr, "Caused by:");
         let _ = wtr.reset();
-        let _ = writeln!(wtr, "\n  {}", cause);
+        let _ = writeln!(wtr, "\n  {cause}");
     }
 
     let _ = wtr.flush();

--- a/src/oj_api.rs
+++ b/src/oj_api.rs
@@ -120,13 +120,13 @@ fn call<T: DeserializeOwned, S: AsRef<OsStr>>(
 
     return if let Ok(result) = result {
         for message in messages {
-            shell.warn(format!("oj-api: {}", message))?;
+            shell.warn(format!("oj-api: {message}"))?;
         }
         Ok(result)
     } else {
         bail!(
             "`oj-api` returned error:\n{}",
-            messages.iter().map(|s| format!("- {}\n", s)).join(""),
+            messages.iter().map(|s| format!("- {s}\n")).join(""),
         );
     };
 
@@ -156,8 +156,7 @@ fn call<T: DeserializeOwned, S: AsRef<OsStr>>(
                     messages,
                 }),
                 status => Err(D::Error::custom(format!(
-                    "expected \"ok\" or \"error\", got {:?}",
-                    status,
+                    "expected \"ok\" or \"error\", got {status:?}",
                 ))),
             };
 

--- a/src/project.rs
+++ b/src/project.rs
@@ -197,8 +197,7 @@ impl cm::Package {
 
         for unused in &*unused {
             shell.warn(format!(
-                "unused key in `package.metadata.cargo-compete`: {}",
-                unused,
+                "unused key in `package.metadata.cargo-compete`: {unused}",
             ))?;
         }
 

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -61,7 +61,7 @@ impl Shell {
         write!(stderr, "warning:")?;
         stderr.reset()?;
 
-        writeln!(stderr, " {}", message)?;
+        writeln!(stderr, " {message}")?;
 
         stderr.flush()
     }
@@ -118,7 +118,7 @@ impl Shell {
 
         let stderr = self.err();
 
-        write!(stderr, "{}", prompt)?;
+        write!(stderr, "{prompt}")?;
         stderr.flush()?;
         self.input.read_reply()
     }
@@ -130,7 +130,7 @@ impl Shell {
 
         let stderr = self.err();
 
-        write!(stderr, "{}", prompt)?;
+        write!(stderr, "{prompt}")?;
         stderr.flush()?;
         self.input.read_password()
     }
@@ -289,10 +289,10 @@ impl ShellOut {
         let stderr = self.stderr();
 
         stderr.set_color(color_spec!(Bold, Fg(color)))?;
-        write!(stderr, "{:>12}", status)?;
+        write!(stderr, "{status:>12}")?;
         stderr.reset()?;
 
-        writeln!(stderr, " {}", message)?;
+        writeln!(stderr, " {message}")?;
         stderr.flush()
     }
 }

--- a/src/web/retrieve_testcases.rs
+++ b/src/web/retrieve_testcases.rs
@@ -90,7 +90,7 @@ pub(crate) fn dl_only_system_test_cases(
     }
 
     for (name, (input, output)) in text_files {
-        let file_name = &format!("{}.txt", name);
+        let file_name = &format!("{name}.txt");
         crate::fs::write(in_dir.join(file_name), input)?;
         if let Some(output) = output {
             crate::fs::write(out_dir.join(file_name), output)?;
@@ -151,7 +151,7 @@ pub(crate) fn dl_for_existing_package(
     }
 
     for bin_name_or_alias in bin_name_aliases.into_iter().flatten() {
-        shell.warn(format!("no such `bin`: {}", bin_name_or_alias))?;
+        shell.warn(format!("no such `bin`: {bin_name_or_alias}"))?;
     }
 
     let mut outcome = vec![];
@@ -407,7 +407,7 @@ pub(crate) fn save_test_cases<I>(
             if let TestSuite::Batch(BatchTestSuite { cases, extend, .. }) = &mut test_suite {
                 if text_files.is_empty() {
                     extend.push(Additional::Text {
-                        path: format!("./{}", bin_alias).into(),
+                        path: format!("./{bin_alias}").into(),
                         r#in: "/in/*.txt".to_owned(),
                         out: "/out/*.txt".to_owned(),
                         timelimit: None,
@@ -431,7 +431,7 @@ pub(crate) fn save_test_cases<I>(
                             match cases.len() + text_files.len() {
                                 0 => "no test cases".to_owned(),
                                 1 => "1 test case".to_owned(),
-                                n => format!("{} test cases", n),
+                                n => format!("{n} test cases"),
                             }
                         }
                         TestSuite::Interactive(_) =>
@@ -440,7 +440,7 @@ pub(crate) fn save_test_cases<I>(
                             "no test cases (unsubmittable problem)".to_owned(),
                     },
                     if empty {
-                        path.with_file_name(format!("{}.yml", bin_alias))
+                        path.with_file_name(format!("{bin_alias}.yml"))
                     } else {
                         path.with_file_name(format!(
                             "{{{0}.yml, {0}{1}}}",

--- a/tests/new.rs
+++ b/tests/new.rs
@@ -109,8 +109,7 @@ email = ""
         |workspace_root, output| {
             output
                 .replace(workspace_root.to_str().unwrap(), "{{ cwd }}")
-                .replace('/', "{{ slash_or_backslash }}")
-                .replace('\\', "{{ slash_or_backslash }}")
+                .replace(['/', '\\'], "{{ slash_or_backslash }}")
         },
         |_| Ok(Override::empty()),
     )

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -115,9 +115,6 @@ path = "src/bin/{problem}.rs"
 [dependencies]
 proconio = "=0.3.6"
 "#,
-                    contest = contest,
-                    problem = problem,
-                    url = url,
                 ),
             )?;
 
@@ -148,7 +145,7 @@ proconio = "=0.3.6"
             "t",
             problem,
             "--manifest-path",
-            &format!("./{}/Cargo.toml", contest),
+            &format!("./{contest}/Cargo.toml"),
         ],
         |_, output| {
             macro_rules! lazy_regex(($regex:literal) => (Lazy::new(|| Regex::new($regex).unwrap())));


### PR DESCRIPTION
`cargo clippy --fix --lib --broken-code` で更新し、エラーとなる箇所(該当行にコメント)のみ人力で修正しました。